### PR TITLE
Drop support for PHP 7.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         php-versions:
-          - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"


### PR DESCRIPTION
Violinist.io does not support it either.

Let's tag a new major and drop it here